### PR TITLE
Rename docs to any2bazel + multi-frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Python bytecode
+__pycache__/
+*.py[cod]
+
+# Migration artifacts produced by the tool (live beside the target repo)
+model.*.json
+aquery.json
+diff.json
+actions.ndjson

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # any2bazel
 
-Migrate a C/C++ project from **CMake to Bazel** by generating `BUILD.bazel`
-files and then *iterating until Bazel's actual build actions match the CMake
-reference build*. The migration loop is driven by a **deterministic diff**, so
-each round is cheap and reproducible — an LLM does only the creative work
-(generating and fixing build files), never the mechanical comparison.
+Migrate a project to **Bazel** — from **CMake**, **Maven**, or a **VSCode-style
+npm/esbuild/gulp** build — by extracting what each build system *actually
+compiles and links* into one **canonical action model**, then *iterating until
+Bazel's build actions match the reference build*. The migration loop is driven
+by a **deterministic diff**, so each round is cheap and reproducible — an LLM
+does only the creative work (generating and fixing build files), never the
+mechanical comparison.
+
+> **Formerly `cmake2bazel`.** The engine started as a CMake→Bazel tool and grew
+> a language-neutral, action-based IR with multiple frontends; hence the rename.
+> One artifact still carries the old name: the migration config file is still
+> literally `cmake2bazel.json` (see [The migration config](#the-migration-config-cmake2bazeljson)).
 
 This repo is packaged as a [Claude Code skill](#skill); see [`SKILL.md`](SKILL.md)
 for the agent-facing procedure. The Python core under `scripts/` is a plain
@@ -13,48 +20,65 @@ library you can also run by hand.
 > **Developed for [Claude Code](https://claude.com/claude-code) using Opus 4.8.**
 > It may work with other agents, but this is untested.
 
-## Installing the skill
+## Frontend maturity
 
-The skill must be discoverable for a Claude Code process to invoke `/cmake2bazel`.
-Two ways:
+The engine has a shared action-based IR and a language/mnemonic-aware differ.
+The frontends that feed it are at very different maturity levels:
 
-**A. Install for auto-discovery** (any session sees `/cmake2bazel`). The skill
-directory needs to contain `SKILL.md`; symlink the whole repo into the user
-skills dir:
+| Frontend | Source of truth | Diffs against Bazel | Status |
+|----------|-----------------|--------------------|--------|
+| **CMake** | File API codemodel-v2 (+ `--trace` for `configure_file`) | C/C++ compile + link parity, two stages | **Mature** — the validated path |
+| **Maven** | forked `javac` argument files | Java source-set (`CompileGroup`) parity | **Early** — argv-floor only, no coordinate deps yet |
+| **VSCode / npm** | Node preload instrumenting esbuild / tsc / `child_process` | `<tscompile>` TS emit check (`diff_ts.py`) | **Experimental** — not wired into the main diff loop |
 
-```bash
-ln -s "$PWD" ~/.claude/skills/cmake2bazel
-# or copy if you prefer a snapshot:  cp -R "$PWD" ~/.claude/skills/cmake2bazel
-```
+The **CMake → Bazel** path is the one to trust and the one the rest of this
+document details. Maven and VSCode/npm share the same model and differ
+framework but are newer captures; treat their output as exploratory.
 
-Restart/begin a Claude Code session in any project; `/cmake2bazel` is then
-available. The skill's `scripts/` are referenced by absolute path from the
-install location.
-
-**B. Point a session at the repo** (no install). Start Claude Code and tell it:
-
-> Read `~/GitHub/cmake2bazel/SKILL.md` and follow it to migrate this project.
-
-This works for a one-off but isn't auto-discovered as a `/`-command.
-
-> Note: the **generation** step (writing `BUILD.bazel` from a CMake-only
+> Note: the **generation** step (writing `BUILD.bazel` from a source-only
 > project) is the least-exercised part of the procedure — the engine has been
-> validated against projects that already had Bazel files. Expect the first
-> from-scratch conversion to surface rough edges in step 3.
+> validated primarily against projects that already had Bazel files. Expect the
+> first from-scratch conversion to surface rough edges.
 
 ## How it works
 
-Both build systems are made to emit a structured description of what they
-*actually compile and link*. Each is normalized into one **canonical model**,
-and the models are compared:
+Every build system is made to emit a structured description of what it
+*actually builds*. Each is normalized into one **canonical action model**, and
+the models are compared:
 
 ```
-CMake File API codemodel  ──extract_cmake.py──┐
-                                              ├─► diff.py ─► worklist / converged?
-Bazel aquery jsonproto    ──extract_bazel.py──┘    ▲
-                                                   │
-                          cmake2bazel.json (migration decisions)
+CMake File API codemodel   ──extract_cmake.py───┐
+Maven forked javac argfiles ──extract_maven.py──┤
+npm/esbuild instrumentation ──extract_npm.py────┼─► reconstruct.py ─► diff.py ─► worklist / converged?
+                                                │        ▲
+Bazel aquery jsonproto     ──extract_bazel.py───┘        │
+                                       cmake2bazel.json (migration decisions)
 ```
+
+### The action-based IR
+
+The canonical model (`model.py`) is a faithful, **dumb record of build
+ACTIONS** — it does *not* canonicalize. The neutral floor of an action is its
+**raw argv** (a list of strings), the genuine common denominator across build
+systems: Bazel `aquery` emits argv natively; CMake, Maven, and the npm
+instrumentation synthesize or capture it from their own config.
+
+- **argv is always present** — the faithful `raw` floor.
+- **Structured semantics are annotations over the argv**, filled by a frontend
+  when it knows them (declared inputs/outputs, resolved deps) and **inferred
+  from argv by the differ** when it doesn't. Never lossy; degrades gracefully.
+- **Canonicalization lives in the differ, not the model.** `reconstruct.py`
+  interprets raw actions into comparable views (per-file translation units for
+  C/C++, per-source-set `CompileGroup`s for Java, link flags, deps), keyed on
+  the model's `build_system` tag (for noise stripping) and each action's
+  **mnemonic** (for grouping). `canonicalize.py` is the pure flag-policy layer
+  it calls.
+
+This is the "more complexity in the differ, neutral model" trade documented in
+[`docs/DESIGN-action-based-ir.md`](docs/DESIGN-action-based-ir.md). The
+same comparator framework applies per-language grouping rules: C/C++ compiles
+per file (one TU each); Java compiles a whole source set at once, so its
+comparable unit is the `(sources, flags)` group.
 
 ### Why these data sources
 
@@ -63,20 +87,30 @@ Bazel aquery jsonproto    ──extract_bazel.py──┘    ▲
   Since a buildable binary needs compile **and** link, we use the codemodel,
   which exposes per-target type, the source→flags mapping, and link
   dependencies in one stable, documented schema.
+- **Maven side: the forked `javac` argument file.** Maven has no action graph
+  like aquery. Run `mvn clean compile -Dmaven.compiler.fork=true` and the
+  maven-compiler-plugin writes the exact javac argv it launches to
+  `<module>/target/…JavacCompiler…arguments`. This is the **real** command line,
+  captured not synthesized.
+- **VSCode / npm side: runtime instrumentation.** An npm/gulp/esbuild build has
+  no action graph either. `scripts/npm_instrument/preload.mjs` hooks esbuild,
+  the TypeScript language service, and `child_process` in-process (via
+  `NODE_OPTIONS`) and writes one NDJSON record per build action. No target-repo
+  modification needed.
 - **Bazel side: `bazel aquery`**, which reports the real compile *and* link
-  actions (with full argv), matching the codemodel's coverage.
+  actions (with full argv), matching the reference's coverage.
 
 > **aquery must mirror the real build.** A bare `bazel aquery //...` omits
 > config-gated flags (`--config`/`.bazelrc`) and top-level copts the embedder
 > sets, fabricating false discrepancies. Run it with the same
 > platform/`--config`/copts the project actually builds with, matching the
-> CMake configure. The tool cannot infer top-level flags (e.g. boringssl sets
-> `-fno-exceptions -fno-rtti` at the top level, not in libraries) — pass them
-> through or record the difference in `cmake2bazel.json`.
+> reference configure. The tool cannot infer top-level flags (e.g. boringssl
+> sets `-fno-exceptions -fno-rtti` at the top level, not in libraries) — pass
+> them through or record the difference in `cmake2bazel.json`.
 
 ### The comparison is asymmetric
 
-The diff requires every **correctness-relevant CMake flag** to be present on
+The diff requires every **correctness-relevant reference flag** to be present on
 the Bazel side. Flags that appear *only* on the Bazel side are tolerated. This
 asymmetry is the whole point: it lets a build that is *textually different but
 semantically equivalent* converge to zero errors. Without it, every translation
@@ -104,7 +138,12 @@ deliverables — stay aligned by name; a `target_map` handles intentional
 executable renames. Only **external** link deps are compared; internal dep names
 are noise once libraries are unioned.
 
-Source **presence** is judged across *all* roles, not within one: a `.cc` is
+Java sources compile as a source set rather than per file, so the Maven frontend
+compares them the same way libraries are: a **project-wide union of `.java`
+sources**, grouping- and naming-agnostic (Maven's 2 compile groups vs Bazel's 1
+is irrelevant — the source set is what must match).
+
+Source **presence** is judged across *all* roles, not within one: a source is
 only "missing" if it's compiled **nowhere** on the other side. This matters
 because the same source can be grouped differently per build system — e.g. a
 test helper that CMake compiles straight into a test executable while Bazel puts
@@ -142,12 +181,16 @@ deliberate line:
 
 Hardcoded rules are universal facts baked into the code. Configurable
 suppressions are *judgment calls* and live in a checked-in file (below), so each
-one is reviewable.
+one is reviewable. (Java flag canonicalization is deliberately deferred — the
+Maven path keeps javac flags raw until a real Java-vs-Java diff shows what noise
+to strip.)
 
 ## The migration config: `cmake2bazel.json`
 
 Lives at the **migrated project's repo root**, committed alongside the BUILD
-files as the durable record of migration decisions:
+files as the durable record of migration decisions. The filename still carries
+the old project name (`CONFIG_FILENAME` in `config.py`); it applies to the
+CMake→Bazel path, which is the only frontend that reads it today.
 
 ```json
 {
@@ -203,8 +246,8 @@ files as the durable record of migration decisions:
   `docs/FUTURE-include-order-collision-check.md`.)
 
 Applied at **diff time** to **both sides**, so suppressions can be tuned and
-re-diffed without re-running cmake/bazel. Every entry is an explicit, auditable
-record of a difference a reviewer chose to accept.
+re-diffed without re-running the extraction. Every entry is an explicit,
+auditable record of a difference a reviewer chose to accept.
 
 ## "Done" criterion
 
@@ -212,13 +255,13 @@ Parity is reached in **two stages**, both reported by a single diff run:
 
 - **Compile parity** — every translation unit compiles with canonically-equal
   flags/defines/includes (project-wide TU-set), and the project-wide external
-  link-dependency closure matches.
+  link-dependency closure matches. For Java, the source-set union matches.
 - **Link consistency** — each name-aligned executable / shared library links
   with equivalent link flags (asymmetric subset, toolchain link noise
   stripped). This confirms the build *artifacts* agree, not just their TUs.
 
-A migration is done when both stages converge. There is (deliberately, for now) no
-output-artifact or symbol diff and no test execution — those are candidate
+A migration is done when both stages converge. There is (deliberately, for now)
+no output-artifact or symbol diff and no test execution — those are candidate
 future parity checks.
 
 Test targets (opt-in) get the compile-parity stage: their sources are checked
@@ -230,15 +273,24 @@ of today's "done".
 ## Scope
 
 **Supported (MVP):**
-- Static / shared / object libraries and executables
-- Plain C/C++ sources, compile flags, defines, include presence
-- External link deps recorded as **abstract identities** (resolution to a Bazel
-  label is a pluggable concern, not hardcoded)
-- Tests — opt-in via `include_tests`, compared as a TU-set union + a coarse
-  test-binary count check
+- **CMake → Bazel** (mature): static / shared / object libraries and
+  executables; plain C/C++ sources, compile flags, defines, include presence;
+  external link deps recorded as **abstract identities** (resolution to a Bazel
+  label is a pluggable concern, not hardcoded); tests opt-in via `include_tests`.
+- **Maven → Bazel** (early): a module's forked `javac` compile, compared as a
+  Java source-set union against Bazel's `Javac` actions. argv-floor only —
+  coordinate-identity deps (`group:artifact:version`, scope) are not yet
+  extracted or diffed.
+- **VSCode / npm → Bazel** (experimental): esbuild/tsc/`child_process`
+  instrumentation into the action model; `diff_ts.py` does a standalone TS
+  source→emit check, not integrated with the main C++/Java diff loop.
 
 **Not yet supported:**
-- Custom commands / generated code (`configure_file`, protoc, `add_custom_command`)
+- Coordinate-identity Java deps and Java flag canonicalization (Maven path)
+- npm/TS diff integration into the main loop (VSCode path)
+- Custom commands / build-time generated code (`configure_file` outputs are
+  captured but not yet diffed — see `docs/TODO-configure-time-generation.md`;
+  protoc / `add_custom_command` are unmodeled)
 - Per-test-binary identity alignment (tests compare at TU-set level for now)
 - Include search **order** (presence only — see
   `docs/FUTURE-include-order-collision-check.md`)
@@ -251,24 +303,38 @@ of today's "done".
 
 ```
 scripts/
-  model.py          canonical model: targets, TUs, TargetRole, deps
-  canonicalize.py   flag normalizer — hardcoded mechanics  ← core IP
-  config.py         cmake2bazel.json loader — configurable judgment calls
+  model.py             canonical ACTION model: targets, Actions (raw argv + annotations), roles, deps
+  canonicalize.py      flag normalizer — hardcoded mechanics  ← core IP
+  reconstruct.py       differ's smart layer: raw Actions → comparable views (TUs / CompileGroups / link flags / deps)
+  config.py            cmake2bazel.json loader — configurable judgment calls
   extract_cmake.py     CMake File API codemodel → model.json (+ role classify)
   extract_configure.py cmake --trace → configure_file outputs (configure-time gen)
-  extract_bazel.py  bazel aquery jsonproto  → model.json (+ role classify)
-  diff.py           role-filtered, TU-set parity diff → worklist + converged
-  triage.py         groups diff.json into a systematic-cause worklist
-  serialize.py      model ↔ JSON (the contract between stages)
+  extract_maven.py     Maven forked javac argfiles → model.json (JavaCompile actions)
+  extract_npm.py       npm instrumentation NDJSON → model.json (Esbuild/Ts/Spawn actions)
+  npm_instrument/      Node preload + esbuild/typescript shims that emit the NDJSON
+  extract_bazel.py     bazel aquery jsonproto → model.json (+ role classify)
+  diff.py              role-filtered, TU-set parity diff → worklist + converged
+  diff_ts.py           standalone TS source→emit diff (npm vs bazel <tscompile>) — not yet integrated
+  triage.py            groups diff.json into a systematic-cause worklist
+  serialize.py         model ↔ JSON (the contract between stages)
 tests/
-  test_engine.py      diff/canonicalize/roles/config/TU-set behavior
-  test_extractors.py  full pipeline on synthetic File-API + aquery fixtures
-  test_triage.py      triage grouping/histogram/cap behavior
-  test_configure.py   configure_file trace extraction
-SKILL.md            Claude Code skill: the migrate-iterate procedure
+  test_engine.py       diff/canonicalize/roles/config/TU-set behavior
+  test_extractors.py   full pipeline on synthetic File-API + aquery fixtures
+  test_maven.py        Maven frontend + Java branch of reconstruct
+  test_extract_npm.py  npm frontend (NDJSON → action IR) + role classification
+  test_triage.py       triage grouping/histogram/cap behavior
+  test_configure.py    configure_file trace extraction
+docs/
+  DESIGN-action-based-ir.md    the action-based IR reframe (grounded in CMake/Bazel/Maven)
+  proposal-doc.md              the broader Build IR spec (frontends → IR → backends)
+  TODO-configure-time-generation.md
+  FUTURE-include-order-collision-check.md
+SKILL.md               Claude Code skill: the migrate-iterate procedure
 ```
 
 ## Usage (by hand)
+
+### CMake → Bazel (the mature path)
 
 ```bash
 # 1. CMake reference model
@@ -293,22 +359,50 @@ python3 scripts/diff.py model.cmake.json model.bazel.json cmake2bazel.json > dif
 python3 scripts/triage.py diff.json
 ```
 
-Run as a skill, Claude drives step 2 and the triage/fix loop automatically.
+### Maven → Bazel (early)
+
+```bash
+# Reference: forked javac argfiles (writes <module>/target/*arguments)
+mvn clean compile -Dmaven.compiler.fork=true
+python3 scripts/extract_maven.py <module_dir> "$PWD" model.maven.json
+
+# Bazel side: aquery over Javac actions (mapped to the neutral JavaCompile mnemonic)
+bazel aquery 'mnemonic("Javac", //...)' --output=jsonproto > aquery.json
+python3 scripts/extract_bazel.py aquery.json "$PWD" model.bazel.json
+python3 scripts/diff.py model.maven.json model.bazel.json > diff.json
+```
+
+### VSCode / npm → Bazel (experimental)
+
+```bash
+# Instrument the real build in-process, capturing one NDJSON record per action.
+NODE_OPTIONS="--import file://$PWD/scripts/npm_instrument/preload.mjs" \
+VSCODE_EMIT_BUILD_IR=$PWD/actions.ndjson \
+    npm run <build-script>
+python3 scripts/extract_npm.py actions.ndjson "$PWD" model.npm.json
+
+# Standalone TS source→emit check against a Bazel model (not the main loop).
+python3 scripts/diff_ts.py model.npm.json model.bazel.json
+```
+
+Run as a skill, Claude drives the generation and triage/fix loop automatically.
 
 ## Tests
 
 ```bash
 python3 tests/test_engine.py
 python3 tests/test_extractors.py
+python3 tests/test_maven.py
+python3 tests/test_extract_npm.py
 python3 tests/test_triage.py
 python3 tests/test_configure.py
 ```
 
 The extractor tests run against fixtures under `tests/` that mirror the
-documented File API and aquery schemas. Real projects exercise schema details
-the fixtures may not (fragment quoting, `external/` repo paths in aquery,
-multi-configuration builds); add captured real output as fixtures as you
-encounter it.
+documented File API, aquery, Maven argfile, and npm-NDJSON schemas. Real projects
+exercise schema details the fixtures may not (fragment quoting, `external/` repo
+paths in aquery, multi-configuration builds); add captured real output as
+fixtures as you encounter it.
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: cmake2bazel
-description: Migrate a C/C++ project from CMake to Bazel by iterating until Bazel's build matches the CMake reference build. Use when asked to convert/port a CMake project to Bazel, generate BUILD.bazel files from CMakeLists, or verify Bazel build parity against CMake. MVP scope — no codegen/custom commands.
+name: any2bazel
+description: Migrate a project (CMake, Maven, or a VSCode-style npm/esbuild build) to Bazel by iterating until Bazel's build actions match the reference build. Use when asked to convert/port a CMake/Maven/npm project to Bazel, generate BUILD.bazel files, or verify Bazel build parity against a reference build. CMake→Bazel is the mature path; Maven and npm are newer. MVP scope — no codegen/custom commands.
 user-invocable: true
 allowed-tools:
   - Read
@@ -9,30 +9,54 @@ allowed-tools:
   - Bash
 ---
 
-# /cmake2bazel — CMake → Bazel migration via parity iteration
+# /any2bazel — migrate to Bazel via parity iteration
 
-Migrate a C/C++ project from CMake to Bazel by generating `BUILD.bazel` files,
-then **iterating until Bazel's actual build actions match the CMake reference
-build**. The loop is driven by a deterministic diff, so each round is cheap and
-the LLM only does the creative work (generating and fixing BUILD files), never
-the mechanical comparison.
+Migrate a project to Bazel by generating `BUILD.bazel` files, then **iterating
+until Bazel's actual build actions match the reference build**. The loop is
+driven by a deterministic diff, so each round is cheap and the LLM only does the
+creative work (generating and fixing BUILD files), never the mechanical
+comparison.
+
+> **Formerly `cmake2bazel`.** The engine grew a language-neutral, action-based
+> IR with multiple frontends. One artifact still carries the old name: the
+> migration config file is still literally `cmake2bazel.json`.
+
+## Frontends and maturity
+
+All frontends extract into one shared **action-based model**; a language/
+mnemonic-aware differ compares each against a Bazel `aquery` model.
+
+| Frontend | Reference source | Diffs | Status |
+|----------|------------------|-------|--------|
+| **CMake** | File API codemodel-v2 | C/C++ compile + link parity | **Mature** — the validated path, detailed below |
+| **Maven** | forked `javac` argfiles | Java source-set parity | **Early** — argv-floor only |
+| **VSCode / npm** | esbuild/tsc/`child_process` instrumentation | standalone TS emit check | **Experimental** — not wired into the main loop |
+
+**Trust and detail the CMake path.** The numbered procedure below is the
+CMake→Bazel loop. The Maven and npm frontends share the model and differ but are
+newer captures; see *Other frontends* at the end for how they differ.
 
 ## Core idea
 
-Both build systems are made to emit a structured description of what they
-*actually build*, normalized into one **canonical model**, then compared:
+Each build system is made to emit a structured description of what it *actually
+builds*, normalized into one **canonical action model**, then compared:
 
 ```
 CMake File API codemodel  ──extract_cmake.py──┐
-                                              ├─► diff.py ─► worklist / converged?
-Bazel aquery jsonproto    ──extract_bazel.py──┘    ▲
-                                                   │
+                                              ├─► reconstruct.py ─► diff.py ─► worklist / converged?
+Bazel aquery jsonproto    ──extract_bazel.py──┘        ▲
+                                                       │
                           cmake2bazel.json (migration decisions)
 ```
 
 - **CMake side = File API codemodel-v2** (not `compile_commands.json`, which
   lacks link info). **Bazel side = `bazel aquery`**. Both expose compile *and*
   link actions.
+- **The model stores raw ACTIONS** (argv floor + annotations); all
+  canonicalization/interpretation happens in the differ (`reconstruct.py` +
+  `canonicalize.py` + `diff.py`), keyed on the model's `build_system` tag (for
+  noise) and each action's mnemonic (for grouping). See
+  `docs/DESIGN-action-based-ir.md`.
 - **Parity has two stages**, both reported by one diff run ("steps" below = the
   numbered procedure; these are the *stages* of what's checked):
   - **Compile parity** — every TU compiled with equivalent flags/defines/
@@ -71,7 +95,9 @@ errors by design.
 ## The migration config: `cmake2bazel.json`
 
 Lives at the **migrated project's repo root**, committed alongside the BUILD
-files as the durable record of migration decisions:
+files as the durable record of migration decisions. The filename still carries
+the old project name; it applies to the CMake→Bazel path (the only frontend that
+reads it today):
 
 ```json
 {
@@ -151,9 +177,16 @@ flags. Tests are opt-in (`include_tests`) and get the compile-parity stage only
   only) — both have planned follow-ups
 - Packaging / install rules
 - Automatic external-dependency resolution (find_package → bzlmod)
+- **Maven**: coordinate-identity deps (`group:artifact:version`, scope) and Java
+  flag canonicalization — argv-floor only.
+- **VSCode / npm**: not integrated into this parity loop (`diff_ts.py` is a
+  standalone TS emit check only).
 
 ## Prerequisites
-- `cmake` ≥ 3.14 (File API), `bazel`/`bazelisk`, `python3`
+- `python3`; `bazel`/`bazelisk`
+- CMake path: `cmake` ≥ 3.14 (File API)
+- Maven path: `mvn` (forked-compile capable)
+- VSCode/npm path: `node` (the instrumentation preload)
 
 ## Procedure
 
@@ -162,7 +195,7 @@ flags. Tests are opt-in (`include_tests`) and get the compile-parity stage only
 > NOT the project being migrated. When running inside a target repo, invoke them
 > by absolute path, e.g.
 > `python3 "$SKILL_DIR/scripts/extract_cmake.py" …` where `$SKILL_DIR` is this
-> skill's install location (e.g. `~/.claude/skills/cmake2bazel`). The artifacts
+> skill's install location (e.g. `~/.claude/skills/any2bazel`). The artifacts
 > you *produce* — `model.*.json`, `aquery.json`, `diff.json`, the generated
 > `BUILD.bazel`/`MODULE.bazel`, and `cmake2bazel.json` — live in or beside the
 > target repo.
@@ -317,14 +350,50 @@ test-binary count gap.
 per-iteration judgment goes into the generated `BUILD.bazel`/`MODULE.bazel` and
 `cmake2bazel.json` (reviewed).
 
+## Other frontends
+
+The Maven and VSCode/npm frontends share the action model and differ but are
+newer captures — treat their output as exploratory, and don't apply the CMake
+`cmake2bazel.json` machinery to them (they don't read it).
+
+### Maven → Bazel (early)
+Maven has no action graph; the reference is the **forked `javac` argument
+file**. Java compiles a whole source set at once, so it's compared as a
+project-wide union of `.java` sources (grouping/naming agnostic), analogous to
+how libraries are compared. argv-floor only — coordinate deps aren't extracted.
+```bash
+mvn clean compile -Dmaven.compiler.fork=true          # writes <module>/target/*arguments
+python3 scripts/extract_maven.py <module_dir> <repo_root> model.maven.json
+bazel aquery 'mnemonic("Javac", //...)' --output=jsonproto > aquery.json
+python3 scripts/extract_bazel.py aquery.json <repo_root> model.bazel.json
+python3 scripts/diff.py model.maven.json model.bazel.json > diff.json
+```
+Diff kinds: `missing_java_src` / `extra_java_src` (a `.java` compiled on only
+one side).
+
+### VSCode / npm → Bazel (experimental)
+An npm/gulp/esbuild build is instrumented in-process by a Node preload (hooks
+esbuild, the TS language service, and `child_process`), emitting one NDJSON
+record per action. `diff_ts.py` does a **standalone** TS source→emit check; it
+is not part of the main diff loop.
+```bash
+NODE_OPTIONS="--import file://$SKILL_DIR/scripts/npm_instrument/preload.mjs" \
+VSCODE_EMIT_BUILD_IR=$PWD/actions.ndjson \
+    npm run <build-script>
+python3 scripts/extract_npm.py actions.ndjson <repo_root> model.npm.json
+python3 scripts/diff_ts.py model.npm.json model.bazel.json    # standalone check
+```
+
 ## Tests
 
 ```bash
 python3 tests/test_engine.py && python3 tests/test_extractors.py \
+    && python3 tests/test_maven.py && python3 tests/test_extract_npm.py \
     && python3 tests/test_triage.py && python3 tests/test_configure.py
 ```
 
-Extractor tests run against fixtures that mirror the documented File API and
-aquery schemas. When a real project surfaces a schema detail the extractors
-mishandle (fragment quoting, `external/` repo paths in aquery, multi-config),
-fix the extractor and capture that output as a new fixture.
+Extractor tests run against fixtures that mirror the documented File API,
+aquery, Maven argfile, and npm-NDJSON schemas. When a real project surfaces a
+schema detail the extractors mishandle (fragment quoting, `external/` repo paths
+in aquery, multi-config), fix the extractor and capture that output as a new
+fixture.


### PR DESCRIPTION
- Reframe README/SKILL around the action-based IR with multiple frontends
- Add frontend maturity table (CMake mature, Maven early, npm experimental)
- Add .gitignore for __pycache__ and migration artifacts