### PR TITLE
VSCode: ignore non-existent .d.ts files

### DIFF
--- a/scripts/diff_ts.py
+++ b/scripts/diff_ts.py
@@ -5,13 +5,36 @@ per-file (source -> outputs) maps that extract_npm.py and extract_bazel.py
 produce and reports:
 
   * sources compiled on only one side,
-  * sources whose emitted-file EXTENSIONS differ (.js/.js.map/.d.ts).
+  * sources whose emitted-file EXTENSIONS differ (.js/.js.map).
 
 Absolute path prefixes differ between the two frontends (npm's IR has TS-
 internal `out/vs/vs/...` paths, Bazel's IR has `out-build/vs/...`), so we key
 outputs by their extension suffix only. That's the coarsest useful match --
 enough to say "did both build systems agree on what to produce from src/X.ts?"
 without conflating outDir naming with actual emit disagreement.
+
+## Why `.d.ts` is ignored (differ-side canonicalization)
+
+The npm side over-reports a `.d.ts` for EVERY source, but no `.d.ts` is
+actually written to disk. gulp-tsb (build/lib/tsb/builder.ts) force-sets
+`declaration = true` on the compiler settings so it can hash each file's
+declaration signature for incremental rebuilds -- then DISCARDS the `.d.ts`
+from its output stream unless the tsconfig genuinely requested declarations
+(`if (!userWantsDeclarations) continue;`). The instrumentation shim wraps
+`ts.getEmitOutput`, whose result still contains the `.d.ts` at that point
+(before gulp-tsb drops it), so the captured action lists it. The Bazel side
+runs plain `tsc` against a tsconfig with no `declaration`, so it never emits a
+`.d.ts`. Verified on a real vscode build: 0 `.d.ts` on disk on either side,
+7710 `.js` byte-identical.
+
+`.d.ts` is therefore build-system NOISE in this parity target, not a real
+artifact -- so it's stripped here, in the differ (the model stays a faithful
+record of what `getEmitOutput` returned). This mirrors canonicalize.py's role
+for the C/C++ path: hardcoded, universal noise stripped at diff time. The strip
+is REPORTED (not silent): `diff()` returns how many sources had a `.d.ts`
+suppressed, so an unexpected count is still visible. If a parity target ever
+DOES request declarations on both sides, this constant is the one lever to
+revisit.
 
 Usage:
     python3 diff_ts.py <npm.model.json> <bazel.model.json>
@@ -23,45 +46,71 @@ import json
 import sys
 from typing import Dict, List, Set, Tuple
 
+# Extensions that are not real emitted artifacts in this parity target and are
+# stripped before comparison. See the module docstring for the full rationale.
+_IGNORED_EXTS = frozenset({".d.ts"})
+
+# Multi-dot extensions must be recognized as single tokens, else `.js.map`
+# reads as `.map` and `.d.ts` as `.ts`, hiding real emit differences. Longest
+# first so `.d.ts` wins over a naive `.ts` split.
+_COMPOUND_EXTS = (".js.map", ".d.ts")
+
 
 def _extensions(paths) -> Set[str]:
-    """Return the set of significant extensions in a bag of output paths.
-
-    We treat `.js.map` and `.d.ts` as single-token extensions rather than
-    ".map" / ".ts" -- otherwise the diff would report every side as producing
-    ".ts" and hide the actual difference.
-    """
+    """Return the set of significant, non-ignored extensions in a bag of output
+    paths. Compound extensions (`.js.map`, `.d.ts`) are single tokens; ignored
+    extensions (`.d.ts`) are dropped -- see the module docstring."""
     out: Set[str] = set()
     for p in paths:
-        for ext in (".js.map", ".d.ts"):
+        for ext in _COMPOUND_EXTS:
             if p.endswith(ext):
-                out.add(ext)
+                matched = ext
                 break
         else:
             _, dot, rest = p.rpartition(".")
-            if dot:
-                out.add("." + rest)
+            matched = ("." + rest) if dot else None
+        if matched and matched not in _IGNORED_EXTS:
+            out.add(matched)
     return out
 
 
-def _by_source(model: dict) -> Dict[str, Set[str]]:
-    """Build `source -> emitted extensions` for the `<tscompile>` target.
+def _had_ignored_ext(paths) -> bool:
+    """True if any output path carries an ignored extension -- used to count
+    (and thus surface) how many sources had a `.d.ts` stripped."""
+    for p in paths:
+        for ext in _IGNORED_EXTS:
+            if p.endswith(ext):
+                return True
+    return False
+
+
+def _by_source(model: dict) -> Tuple[Dict[str, Set[str]], int]:
+    """Build `source -> emitted (non-ignored) extensions` for the `<tscompile>`
+    target, plus a count of sources that had an ignored extension (`.d.ts`)
+    stripped -- returned so the strip is reported, never silent.
 
     Sources that appear more than once (e.g. the MonacoGenerator's synthetic
     `file.ts` fires 45x in the npm build) are merged: the union of extensions
     across all calls for that source is what the source's build produces.
     """
     result: Dict[str, Set[str]] = {}
+    stripped_srcs: Set[str] = set()
     t = model.get("targets", {}).get("<tscompile>", {})
     for a in t.get("actions", []):
+        outs = a.get("outputs", [])
+        exts = _extensions(outs)
+        ignored = _had_ignored_ext(outs)
         for inp in a.get("inputs", []):
-            result.setdefault(inp, set()).update(_extensions(a.get("outputs", [])))
-    return result
+            result.setdefault(inp, set()).update(exts)
+            if ignored:
+                stripped_srcs.add(inp)
+    return result, len(stripped_srcs)
 
 
-def diff(npm_model: dict, bazel_model: dict) -> Tuple[List[str], List[str], List[str]]:
-    npm = _by_source(npm_model)
-    bz = _by_source(bazel_model)
+def diff(npm_model: dict,
+         bazel_model: dict) -> Tuple[List[str], List[str], List[str], Dict[str, int]]:
+    npm, npm_stripped = _by_source(npm_model)
+    bz, bz_stripped = _by_source(bazel_model)
     npm_only = sorted(set(npm) - set(bz))
     bazel_only = sorted(set(bz) - set(npm))
     ext_diffs: List[str] = []
@@ -70,7 +119,8 @@ def diff(npm_model: dict, bazel_model: dict) -> Tuple[List[str], List[str], List
             npm_ext = ",".join(sorted(npm[src]))
             bz_ext = ",".join(sorted(bz[src]))
             ext_diffs.append(f"{src}\tnpm={{{npm_ext}}}\tbazel={{{bz_ext}}}")
-    return npm_only, bazel_only, ext_diffs
+    stripped = {"npm": npm_stripped, "bazel": bz_stripped}
+    return npm_only, bazel_only, ext_diffs, stripped
 
 
 def main(argv):
@@ -80,10 +130,13 @@ def main(argv):
         npm_model = json.load(f)
     with open(argv[2]) as f:
         bazel_model = json.load(f)
-    npm_only, bazel_only, ext_diffs = diff(npm_model, bazel_model)
+    npm_only, bazel_only, ext_diffs, stripped = diff(npm_model, bazel_model)
     print(f"sources npm-only:   {len(npm_only)}")
     print(f"sources bazel-only: {len(bazel_only)}")
     print(f"sources w/ ext diff: {len(ext_diffs)}")
+    ignored = ",".join(sorted(_IGNORED_EXTS))
+    print(f"sources w/ ignored ext ({ignored}) stripped: "
+          f"npm={stripped['npm']} bazel={stripped['bazel']}")
     if npm_only[:5]:
         print("\nfirst 5 npm-only sources:")
         for s in npm_only[:5]:

--- a/tests/test_diff_ts.py
+++ b/tests/test_diff_ts.py
@@ -1,0 +1,110 @@
+"""Tests for diff_ts.py -- the standalone npm-vs-Bazel TS emit diff.
+
+Synthetic <tscompile> models (the shape extract_npm.py / extract_bazel.py
+produce). The load-bearing case is the `.d.ts` false positive: gulp-tsb runs
+tsc with declaration=true internally (for incremental signature hashing) then
+discards the .d.ts, so the instrumentation captures a .d.ts the build never
+writes, while the Bazel side (plain tsc, no declaration) emits none. The differ
+must treat .d.ts as noise so this does NOT read as an emit divergence -- but
+must still REPORT that it stripped them.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import diff_ts
+
+
+def _model(actions):
+    return {"targets": {"<tscompile>": {"actions": actions}}}
+
+
+def _act(src, outputs):
+    return {"mnemonic": "TsCompile", "inputs": [src], "outputs": outputs}
+
+
+def test_dts_only_on_npm_is_not_a_diff():
+    # npm emits .js/.js.map/.d.ts; bazel emits .js/.js.map. The .d.ts is the
+    # discarded declaration artifact -- must not surface as an ext diff.
+    npm = _model([
+        _act("src/a.ts", ["out/a.js", "out/a.js.map", "out/a.d.ts"]),
+        _act("src/b.ts", ["out/b.js", "out/b.js.map", "out/b.d.ts"]),
+    ])
+    bz = _model([
+        _act("src/a.ts", ["out-build/a.js", "out-build/a.js.map"]),
+        _act("src/b.ts", ["out-build/b.js", "out-build/b.js.map"]),
+    ])
+    npm_only, bazel_only, ext_diffs, stripped = diff_ts.diff(npm, bz)
+    assert npm_only == []
+    assert bazel_only == []
+    assert ext_diffs == [], ext_diffs
+    # ...but the strip is reported: every npm source had a .d.ts suppressed.
+    assert stripped == {"npm": 2, "bazel": 0}, stripped
+
+
+def test_real_ext_diff_still_surfaces():
+    # A genuine disagreement -- npm produced a .js.map bazel didn't -- must
+    # still be caught after .d.ts stripping.
+    npm = _model([_act("src/a.ts", ["out/a.js", "out/a.js.map", "out/a.d.ts"])])
+    bz = _model([_act("src/a.ts", ["out-build/a.js"])])
+    npm_only, bazel_only, ext_diffs, _ = diff_ts.diff(npm, bz)
+    assert npm_only == [] and bazel_only == []
+    assert len(ext_diffs) == 1
+    assert "src/a.ts" in ext_diffs[0]
+    assert ".js.map" in ext_diffs[0]
+    # the ignored .d.ts must not appear in the reported extension sets
+    assert ".d.ts" not in ext_diffs[0]
+
+
+def test_source_only_on_one_side():
+    npm = _model([
+        _act("src/a.ts", ["out/a.js"]),
+        _act("src/only_npm.ts", ["out/only_npm.js"]),
+    ])
+    bz = _model([
+        _act("src/a.ts", ["out-build/a.js"]),
+        _act("src/only_bazel.ts", ["out-build/only_bazel.js"]),
+    ])
+    npm_only, bazel_only, ext_diffs, _ = diff_ts.diff(npm, bz)
+    assert npm_only == ["src/only_npm.ts"]
+    assert bazel_only == ["src/only_bazel.ts"]
+    assert ext_diffs == []
+
+
+def test_compound_extension_tokens():
+    # .js.map must read as one token, not ".map"; .d.ts as one token (and then
+    # be stripped), not ".ts".
+    assert diff_ts._extensions(["x.js.map"]) == {".js.map"}
+    assert diff_ts._extensions(["x.js"]) == {".js"}
+    # .d.ts is recognized (compound) AND stripped -> empty significant set.
+    assert diff_ts._extensions(["x.d.ts"]) == set()
+    assert diff_ts._extensions(["x.js", "x.js.map", "x.d.ts"]) == {".js", ".js.map"}
+
+
+def test_same_source_multiple_actions_union():
+    # A source compiled in several actions (e.g. synthetic file.ts) unions its
+    # extensions; a .d.ts in any of them is stripped but still counted.
+    npm = _model([
+        _act("src/dup.ts", ["out/dup.js"]),
+        _act("src/dup.ts", ["out/dup.js.map", "out/dup.d.ts"]),
+    ])
+    bz = _model([_act("src/dup.ts", ["out-build/dup.js", "out-build/dup.js.map"])])
+    npm_only, bazel_only, ext_diffs, stripped = diff_ts.diff(npm, bz)
+    assert npm_only == [] and bazel_only == []
+    assert ext_diffs == [], ext_diffs
+    assert stripped["npm"] == 1
+
+
+if __name__ == "__main__":
+    import traceback
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for fn in fns:
+        try:
+            fn(); print(f"PASS {fn.__name__}")
+        except Exception:
+            failed += 1; print(f"FAIL {fn.__name__}"); traceback.print_exc()
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
gulp-tsb force-sets declaration=true for incremental signature hashing then discards the .d.ts unless the tsconfig requested declarations, so the instrumentation shim (wrapping ts.getEmitOutput) captures a .d.ts that is never written to disk. The Bazel side runs plain tsc with no declaration and emits none. This made every one of ~7675 shared sources show a false extension diff (npm={.d.ts,.js,.js.map} vs {.js,.js.map}) while the on-disk .js output was byte-identical.

Treat .d.ts as build-system noise and strip it at diff time (the differ, not the model -- mirroring canonicalize.py for the C/C++ path). The strip is reported, not silent: diff() returns a per-side count of sources that had a .d.ts suppressed, surfaced in the CLI output.

Adds tests/test_diff_ts.py (no prior coverage): the .d.ts false positive is neutralized, real ext diffs still surface, npm-only/bazel-only detection, compound-extension tokenization, and the reported strip count.