### PR TITLE
Consider local libraries as non-external

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 __pycache__/
 *.py[cod]
 
+# Local symlink to a target repo used for a migration dry-run (Dolphin)
+dolphin_migration
+
 # Migration artifacts produced by the tool (live beside the target repo)
 model.*.json
 aquery.json

--- a/scripts/diff.py
+++ b/scripts/diff.py
@@ -359,8 +359,16 @@ def diff_models(a: CanonicalModel, b: CanonicalModel,
     # vs Bazel's 'catch2_main', or 'OpenSSL::SSL' vs 'ssl') is aligned by an
     # explicit, recorded cfg.dep_map entry -- not a fuzzy match -- so a residual
     # missing_dep is a genuinely-absent dep, not a naming artifact.
-    a_ext = {cfg.dep_map.get(d, d) for d in _external_deps(a_views, a_names)}
-    b_ext = _external_deps(b_views, b_names)
+    # An "external" dep naming a target that EXISTS as an in-project target
+    # (either side) is not truly external -- it's an internal lib the CMake
+    # File-API surfaced as a link fragment (common with cyclically-linked
+    # static libs, whose .a is repeated on the link line but which are not a
+    # direct structural dependency). Such names are verified via the compile
+    # TU-set of that target, so drop them from the external closure.
+    _internal_names = set(a_views) | set(b_views)
+    a_ext = {cfg.dep_map.get(d, d) for d in _external_deps(a_views, a_names)
+             if cfg.dep_map.get(d, d) not in _internal_names and d not in _internal_names}
+    b_ext = {d for d in _external_deps(b_views, b_names) if d not in _internal_names}
     for dep in sorted(a_ext - b_ext):
         out.append(Discrepancy(Kind.MISSING_DEP.value, Severity.ERROR.value,
                                "<external>", "external link dependency missing on bazel side",

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -126,6 +126,41 @@ def test_missing_external_link_dep_is_error():
     assert any(d.kind == "missing_dep" and d.severity == "error" for d in discs)
 
 
+def test_external_dep_naming_an_in_project_target_is_not_missing():
+    # A dep flagged external=True whose name matches an in-project target is
+    # NOT truly external -- the CMake File-API surfaces cyclically-linked static
+    # libs as repeated link fragments (e.g. common<->core), so `common` shows up
+    # on core's link line as an "external" even though it's an in-project lib.
+    # Its sources are verified via the TU-set, so it must NOT be reported as a
+    # missing external dep even when the bazel side doesn't repeat the fragment.
+    a = _bs(CanonicalModel(), is_bazel=False)
+    a.add(Target("common", TargetKind.STATIC, role=TargetRole.PRODUCTION,
+                 actions=[tu_from_raw("common/c.cpp", ["-DFOO=1"], is_bazel=False)]))
+    a.add(Target("core", TargetKind.STATIC, role=TargetRole.PRODUCTION,
+                 actions=[tu_from_raw("core/a.cpp", ["-DFOO=1"], is_bazel=False)],
+                 deps=[Dependency("common", external=True),
+                       Dependency("z", external=True)]))
+    b = _bs(CanonicalModel(), is_bazel=True)
+    b.add(Target("common", TargetKind.STATIC, role=TargetRole.PRODUCTION,
+                 actions=[tu_from_raw("common/c.cpp", ["-DFOO=1"], is_bazel=True)]))
+    b.add(Target("core", TargetKind.STATIC, role=TargetRole.PRODUCTION,
+                 actions=[tu_from_raw("core/a.cpp", ["-DFOO=1"], is_bazel=True)],
+                 deps=[Dependency("z", external=True)]))  # no repeated `common`
+    discs = diff_models(a, b)
+    # `common` must NOT be a missing external dep (it's an in-project target)...
+    assert not any(d.kind == "missing_dep" and "common" in (d.cmake_only or [])
+                   for d in discs), discs
+    # ...but a genuinely-absent external (drop `z` on bazel) still is.
+    b2 = _bs(CanonicalModel(), is_bazel=True)
+    b2.add(Target("common", TargetKind.STATIC, role=TargetRole.PRODUCTION,
+                  actions=[tu_from_raw("common/c.cpp", ["-DFOO=1"], is_bazel=True)]))
+    b2.add(Target("core", TargetKind.STATIC, role=TargetRole.PRODUCTION,
+                  actions=[tu_from_raw("core/a.cpp", ["-DFOO=1"], is_bazel=True)]))
+    discs2 = diff_models(a, b2)
+    assert any(d.kind == "missing_dep" and "z" in (d.cmake_only or [])
+               for d in discs2), discs2
+
+
 def test_external_dep_name_aligned_by_dep_map():
     # CMake records the archive basename ('Catch2Main'); Bazel the target/file
     # name ('catch2_main'). An explicit dep_map aligns them -> converges.


### PR DESCRIPTION
The CMake File-API surfaces cyclically-linked static libs (e.g. Dolphin's common<->core) as repeated link fragments, so an in-project library shows up on another target's link line flagged external=True. Such a name is not truly external -- its sources are already verified via the TU-set -- so drop names matching an in-project target (either side) from the external closure. A genuinely-absent external still surfaces.

Adds a regression test (both the false-positive suppression and the real-gap-still-caught direction). Also gitignores the local dolphin_migration symlink used for the migration dry-run.

AI-Assisted: Claude Code, Anthropic Opus 4.8