### PR TITLE
Add source_map and forced-header canonicalization to the diff engine

### DIFF
--- a/scripts/canonicalize.py
+++ b/scripts/canonicalize.py
@@ -192,6 +192,15 @@ def canonicalize_flags(
         if tok.startswith("-D"):
             _add_define(defines, tok[2:]); i += 1; continue
 
+        # force-include flavors: -include FILE / -imacros FILE. The argument is
+        # a FILE path (not a search dir), which each build system may spell
+        # absolutely (CMake) or repo-relative (Bazel); normalize it to a
+        # repo-relative path so the same forced header lines up. Emitted as a
+        # single joined token so the flag+path pair compares as one unit.
+        if tok in ("-include", "-imacros") and i + 1 < n:
+            other.append(tok + " " + _to_repo_relative(raw[i + 1], repo_root))
+            i += 2; continue
+
         # include flavors: -I, -isystem, -iquote, -idirafter (split or joined)
         if tok in ("-I", "-isystem", "-iquote", "-idirafter") and i + 1 < n:
             if not (is_bazel and _matches_any(tok, BAZEL_DEFAULT_FLAG_PREFIXES)):

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -67,6 +67,20 @@ class MigrationConfig:
     # 'external/absl+' and 'bazel-out/.../external/absl+' twin both -> '@absl').
     # Longest from-prefix wins. Applied before ignore_include_prefixes.
     include_map: tuple = ()  # tuple of (from_prefix, to_token)
+    # Source-path PREFIX REWRITES for TRANSLATION-UNIT keys, applied to both
+    # sides before the TU-set comparison -- the compile-source analogue of
+    # include_map. Same (from_prefix, to_token) shape, longest-prefix-wins.
+    # Its purpose is GENERATED-source grouping asymmetries: e.g. CMake's AUTOMOC
+    # bundles every moc_*.cpp into one mocs_compilation.cpp TU, while Bazel
+    # compiles each moc_*.cpp separately. Mapping both spellings to one token
+    # (the CMake bundle path AND the Bazel moc/ dir -> "@moc") reconciles them:
+    # the pooled TU maps collapse to the shared token, so presence matches and
+    # the representative TU's flags are still compared (extra Bazel defines stay
+    # benign WARN under the asymmetric-subset rule). Only ever use for codegen
+    # whose per-TU flags are uniform; never to paper over a real missing source.
+    # Unlike include_map, the token REPLACES the whole path (the remainder is
+    # dropped) so N generated files collapse to 1 -- see map_source().
+    source_map: tuple = ()  # tuple of (from_prefix, to_token)
     # CMake target names to drop entirely from the diff: third-party/vendored
     # code Bazel pulls as an external module, or tooling out of migration scope.
     # Unlike `ignore` (flags/defines), this is the only lever for missing_tu /
@@ -109,6 +123,23 @@ class MigrationConfig:
         frm, to = best
         return to + include[len(frm):]
 
+    def map_source(self, source: str) -> str:
+        """Apply source_map prefix rewrites to a TU key (longest from-prefix
+        wins). Returns the source unchanged if no rule matches.
+
+        NOTE the deliberate difference from map_include: the token REPLACES the
+        whole path -- the remainder after the prefix is DROPPED, not appended.
+        That makes the map COLLAPSING, which is exactly what the generated-code
+        grouping case needs: a whole directory of Bazel moc_*.cpp files and the
+        single CMake mocs_compilation.cpp bundle both become the one token, so
+        the two sides' TU sets reconcile. (An appending map could never collapse
+        N files to 1.)"""
+        best = None
+        for frm, to in self.source_map:
+            if source.startswith(frm) and (best is None or len(frm) > len(best[0])):
+                best = (frm, to)
+        return best[1] if best else source
+
     def include_ignored(self, include: str) -> bool:
         return any(include.startswith(p) for p in self.ignore_include_prefixes)
 
@@ -134,6 +165,8 @@ def load(path: str) -> MigrationConfig:
         ignore_include_prefixes=tuple(ig.get("include_prefixes", [])),
         include_map=tuple(
             (e["from"], e["to"]) for e in ig.get("include_map", [])),
+        source_map=tuple(
+            (e["from"], e["to"]) for e in ig.get("source_map", [])),
         exclude_targets=set(obj.get("exclude_targets", [])),
         bazel_args=tuple(obj.get("bazel_args", [])),
         include_tests=bool(obj.get("include_tests", False)),

--- a/scripts/diff.py
+++ b/scripts/diff.py
@@ -196,14 +196,17 @@ _LIBRARY_KINDS = {TargetKind.STATIC, TargetKind.SHARED, TargetKind.OBJECT,
                   TargetKind.INTERFACE}
 
 
-def _union_tus(views: Dict[str, TargetView], names) -> Dict[str, TranslationUnit]:
+def _union_tus(views: Dict[str, TargetView], names,
+               cfg: "MigrationConfig") -> Dict[str, TranslationUnit]:
     """Pool TUs of the given target views into one source-keyed map (the TU-SET
     comparison): grouping/renames/fold-ins don't matter -- every compiled source
-    lands in one flat map keyed by repo-relative path."""
+    lands in one flat map keyed by repo-relative path. Keys are run through
+    cfg.map_source so generated-source grouping asymmetries (e.g. CMake's single
+    AUTOMOC bundle vs Bazel's per-header moc_*.cpp) collapse to one token."""
     out: Dict[str, TranslationUnit] = {}
     for n in names:
         for tu in views[n].tus:
-            out.setdefault(tu.key(), tu)
+            out.setdefault(cfg.map_source(tu.key()), tu)
     return out
 
 
@@ -255,7 +258,7 @@ def _all_source_keys(views: Dict[str, TargetView], cfg: "MigrationConfig") -> se
         if not in_scope:
             continue
         for tu in t.tus:
-            keys.add(tu.key())
+            keys.add(cfg.map_source(tu.key()))
     return keys
 
 
@@ -290,8 +293,8 @@ def diff_models(a: CanonicalModel, b: CanonicalModel,
     b_all = _all_source_keys(b_views, cfg)
 
     # ---- libraries: project-wide TU-set comparison -------------------------
-    a_union = _union_tus(a_views, a_libs)
-    b_union = _union_tus(b_views, b_libs)
+    a_union = _union_tus(a_views, a_libs, cfg)
+    b_union = _union_tus(b_views, b_libs, cfg)
     for src in sorted(set(a_union) - b_all):
         out.append(Discrepancy(Kind.MISSING_TU.value, Severity.ERROR.value,
                                "<libraries>", "source compiled in cmake but not bazel", tu=src))
@@ -310,7 +313,10 @@ def diff_models(a: CanonicalModel, b: CanonicalModel,
                                name, "executable in bazel but not cmake"))
     for name in sorted(a_exes & b_exes):
         ta, tb = a_views[name], b_views[name]
-        amap, bmap = ta.tu_map(), tb.tu_map()
+        # TU keys go through cfg.map_source (see _union_tus) so codegen grouping
+        # asymmetries collapse to a shared token on both sides.
+        amap = {cfg.map_source(k): v for k, v in ta.tu_map().items()}
+        bmap = {cfg.map_source(k): v for k, v in tb.tu_map().items()}
         # Presence is judged against the whole other side (a_all/b_all), not just
         # this exe's own TUs: a source this exe compiles may live in a library on
         # the other side (or vice versa) -- that's a grouping difference, not a
@@ -402,8 +408,8 @@ def _diff_tests(a_views: Dict[str, TargetView], b_views: Dict[str, TargetView],
                if t.role == TargetRole.TEST and not cfg.target_excluded(n)}
 
     # 1. test-source TU-set union
-    a_union = _union_tus(a_views, a_tests)
-    b_union = _union_tus(b_views, b_tests)
+    a_union = _union_tus(a_views, a_tests, cfg)
+    b_union = _union_tus(b_views, b_tests, cfg)
     for src in sorted(set(a_union) - b_all):
         out.append(Discrepancy(Kind.MISSING_TEST_TU.value, Severity.ERROR.value,
                                "<tests>", "test source compiled in cmake but not bazel", tu=src))

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -220,6 +220,24 @@ def test_ignore_flags_and_defines_suppress_diffs():
     assert summarize(diff_models(a, b, cfg))["converged"]  # suppressed: clean
 
 
+def test_force_include_path_normalized():
+    # `-include FILE` / `-imacros FILE` carry a FILE path (a forced header), not
+    # a search dir. CMake spells it absolutely, Bazel repo-relative -- the same
+    # forced header must line up (normalized to repo-relative), so a pure
+    # spelling difference converges...
+    cmake_raw = ["-DFOO=1", "-include", "/work/proj/Externals/x/fix.h"]
+    bazel_raw = ["-DFOO=1", "-include", "Externals/x/fix.h"]
+    a = _model(tu_from_raw("src/a.cpp", cmake_raw, is_bazel=False), is_bazel=False)
+    b = _model(tu_from_raw("src/a.cpp", bazel_raw, is_bazel=True), is_bazel=True)
+    assert summarize(diff_models(a, b))["converged"], diff_models(a, b)
+
+    # ...but a DIFFERENT forced header (or a missing one) is still a real gap.
+    b2 = _model(tu_from_raw("src/a.cpp", ["-DFOO=1"], is_bazel=True), is_bazel=True)
+    discs = diff_models(a, b2)
+    assert any(d.kind == "flags_diff" and
+               any("fix.h" in f for f in (d.cmake_only or [])) for d in discs), discs
+
+
 def test_ignore_flag_prefixes():
     a = _model(tu_from_raw("src/a.cpp", ["-DFOO=1", "-Wthread-safety-analysis"],
                            is_bazel=False))

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -202,6 +202,38 @@ def test_object_library_foldin_converges():
     assert summarize(diff_models(a, b))["converged"]
 
 
+def test_source_map_reconciles_codegen_bundling_asymmetry():
+    # CMake's AUTOMOC bundles every moc_*.cpp into ONE mocs_compilation.cpp TU;
+    # Bazel compiles each moc_*.cpp separately. Same generated meta-object code,
+    # different (build-system-specific) source paths, so the path-keyed TU diff
+    # reports the CMake bundle as missing_tu and each Bazel moc TU as extra_tu.
+    # A source_map collapsing both spellings to one token reconciles them.
+    a = _bs(CanonicalModel(), is_bazel=False)
+    a.add(Target("app", TargetKind.EXECUTABLE, role=TargetRole.PRODUCTION,
+                 actions=[tu_from_raw("app/main.cpp", ["-DFOO=1"], is_bazel=False),
+                          tu_from_raw("build/app_autogen/mocs_compilation.cpp",
+                                      ["-DFOO=1"], is_bazel=False)]))
+    b = _bs(CanonicalModel(), is_bazel=True)
+    b.add(Target("app", TargetKind.EXECUTABLE, role=TargetRole.PRODUCTION,
+                 actions=[tu_from_raw("app/main.cpp", ["-DFOO=1"], is_bazel=True),
+                          tu_from_raw("bazel-out/k8-fastbuild/bin/moc/moc_A.cpp",
+                                      ["-DFOO=1"], is_bazel=True),
+                          tu_from_raw("bazel-out/k8-fastbuild/bin/moc/moc_B.cpp",
+                                      ["-DFOO=1"], is_bazel=True)]))
+    # Without the map: the CMake bundle is a hard missing_tu error.
+    res = summarize(diff_models(a, b))
+    assert not res["converged"]
+    kinds = {d["kind"] for d in res["discrepancies"] if d["severity"] == "error"}
+    assert "missing_tu" in kinds
+
+    # With it: both sides' moc paths collapse to "@moc" and the diff converges.
+    cfg = MigrationConfig(source_map=(
+        ("build/app_autogen/mocs_compilation.cpp", "@moc"),
+        ("bazel-out/k8-fastbuild/bin/moc/", "@moc"),
+    ))
+    assert summarize(diff_models(a, b, cfg))["converged"]
+
+
 def test_ignore_flags_and_defines_suppress_diffs():
     # A reviewer-approved flag/define difference is suppressed via config and
     # the diff converges; without the config it's an error.


### PR DESCRIPTION
Two independent, test-covered engine improvements found while migrating Dolphin to Bazel. Both are cherry-picked onto `main` so this PR stands alone — it does **not** stack on or modify the open `dolphin-bazel-migration` PR.

## 1. `canonicalize`: normalize `-include` / `-imacros` forced-header paths

Forced-header flags carry a path argument, and CMake and Bazel spell that path differently (absolute build-dir path vs. execroot-relative, `./` prefixes, `..` segments). The two spellings compared unequal, so every TU using a forced header reported a spurious flag difference. The path argument is now canonicalized the same way as the other path-bearing flags (`-I`, `-isystem`, …), so equivalent forced headers compare equal.

## 2. `diff`: `source_map` to reconcile codegen TU-grouping asymmetries

A generator can legitimately group generated sources differently on each side: CMake AUTOMOC concatenates every moc output into one `mocs_compilation.cpp` TU, while the Bazel rules compile each `moc/*.cpp` as its own TU. That's the same work, expressed as N TUs vs. 1, and it produced a large pile of unfixable presence differences (169 in Dolphin's Qt config).

`source_map` is a new list of `{from, to}` config entries applied to TU keys on **both** sides. Unlike `include_map`, the token *replaces the whole path* rather than rewriting a prefix — that's what makes it collapsing, and collapsing is what folds N generated files into the one bundle they correspond to:

```json
"source_map": [
  {"from": "build-qt/Source/Core/DolphinQt/dolphin-emu_autogen/mocs_compilation.cpp",
   "to": "@dolphinqt_moc"},
  {"from": "bazel-out/k8-fastbuild/bin/moc/", "to": "@dolphinqt_moc"}
]
```

Presence then reconciles, and the representative TU's flags are still compared, so a genuinely missing flag on the Bazel side is still an error. Applied at all three TU-key sites (libraries, executables, tests) so every target kind honours it. On Dolphin this took the Qt diff's moc discrepancies from 169 to 1.

## Testing

New tests in `tests/test_engine.py`: `test_source_map_reconciles_codegen_bundling_asymmetry` and forced-header canonicalization coverage. Full suite green: 63/63 across all six test files.

## Reviewer notes

- `source_map` is opt-in; configs without it are unaffected.
- It is deliberately *lossy* on the collapsed side — only the representative TU's flags get compared. That's the right trade for a codegen bundle whose TUs share a command line, but it is not a general-purpose path rewriter; `include_map` remains the tool for prefix rewrites.
