### PR TITLE
Fix OOM in Bazel depSet resolution

### DIFF
--- a/scripts/extract_bazel.py
+++ b/scripts/extract_bazel.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import json
 import os
 import sys
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional
 
 from model import (Action, BuildSystem, CanonicalModel, Target, TargetKind,
                    TargetRole)
@@ -109,31 +109,54 @@ def _is_real_compile(args) -> bool:
     return any(a.endswith(_REAL_SOURCE_EXTS) for a in args)
 
 
-def _build_depset_index(container: dict) -> Dict[int, List[int]]:
-    """Flatten each depSetOfFiles to a list of leaf artifact IDs.
+class DepsetResolver:
+    """Resolves an action's `inputDepSetIds` to its leaf artifact IDs.
 
     Bazel aquery represents an action's input closure as a DAG of depSets
-    (`directArtifactIds` + `transitiveDepSetIds`). For TsProgram there's one
-    flat depSet, but we handle the general case so the extractor works for any
-    future custom rule that shares depSets via transitivity.
+    (`directArtifactIds` + `transitiveDepSetIds`), heavily shared between
+    actions. Two properties of that DAG make the obvious implementation
+    unusable, and both were learned the hard way on cloudflare/workerd, whose
+    //src/... graph has 722 C++ actions over 2052 depSets:
+
+    * **It is a DAG, not a tree.** A depSet reachable by k distinct paths gets
+      visited k times, so concatenating child results counts *paths*, not
+      *nodes*. On workerd (2052 depSets) that reached 349M artifact IDs and
+      2.7GB RSS before the OOM killer; the deduplicated closure of the whole
+      graph is 5.6M IDs, and the largest single closure is 13k.
+    * **Only a couple of actions ever need it.** Just the TS path consumes
+      input closures. Eagerly indexing all depSets did the work for every one
+      of them (all of it discarded on a project with no TS actions at all).
+
+    So: walk the DAG on demand with a visited set (linear in nodes+edges, no
+    revisits), and don't memoize whole closures -- the overlap between closures
+    is exactly what made materializing them expensive. `resolve()` is called
+    once per consuming action, which is a handful of times per build.
     """
-    dsets = {d["id"]: d for d in container.get("depSetOfFiles", [])}
-    cache: Dict[int, List[int]] = {}
 
-    def flatten(did: int) -> List[int]:
-        if did in cache:
-            return cache[did]
-        d = dsets.get(did)
-        if d is None:
-            cache[did] = []
-            return []
-        out = list(d.get("directArtifactIds", []))
-        for tid in d.get("transitiveDepSetIds", []):
-            out.extend(flatten(tid))
-        cache[did] = out
-        return out
+    def __init__(self, container: dict):
+        self._dsets = {d["id"]: d for d in container.get("depSetOfFiles", [])}
 
-    return {did: flatten(did) for did in dsets}
+    def resolve(self, dsids: Iterable[int]) -> List[int]:
+        """Leaf artifact IDs of the union of `dsids`, deduped, first-seen order.
+
+        Order is deterministic (so model output is reproducible) but carries no
+        meaning -- callers key artifacts by path, not position.
+        """
+        out: Dict[int, None] = {}       # ordered set
+        seen: set = set()
+        stack = list(dsids)
+        while stack:
+            did = stack.pop()
+            if did in seen:
+                continue
+            seen.add(did)
+            d = self._dsets.get(did)
+            if d is None:
+                continue
+            for aid in d.get("directArtifactIds", []):
+                out[aid] = None
+            stack.extend(d.get("transitiveDepSetIds", []))
+        return list(out)
 
 
 def _out_dir_from_args(args) -> str:
@@ -187,22 +210,15 @@ def _ts_output_paths(src_relpath: str, out_dir: str) -> List[str]:
 
 def _extract_ts_program(action: dict, out_dir: str,
                         artifacts: Dict[int, str],
-                        depsets: Dict[int, List[int]]) -> List[Action]:
+                        depsets: DepsetResolver) -> List[Action]:
     """Split one TsProgram action into per-source TsCompile actions.
 
     Mirrors the npm side's `<tscompile>` structure (per-file). Only .ts inputs
     under src/ that emit .js are considered; type-only .d.ts inputs and
     node_modules/type_deps inputs are filtered out.
     """
-    input_ids: List[int] = []
-    for dsid in action.get("inputDepSetIds", []):
-        input_ids.extend(depsets.get(dsid, []))
-    seen = set()
     actions: List[Action] = []
-    for aid in input_ids:
-        if aid in seen:
-            continue
-        seen.add(aid)
+    for aid in depsets.resolve(action.get("inputDepSetIds", [])):
         path = artifacts.get(aid, "")
         if not path.startswith("src/") or not path.endswith(".ts"):
             continue
@@ -226,7 +242,7 @@ def extract(aquery_path: str, repo_root: str) -> CanonicalModel:
 
     artifacts = _build_path_index(container)
     labels = _label_index(container)
-    depsets = _build_depset_index(container)
+    depsets = DepsetResolver(container)
 
     model = CanonicalModel(build_system=BuildSystem.BAZEL, repo_root=repo_root)
     by_target: Dict[str, Target] = {}

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -277,6 +277,163 @@ def test_bazel_recovers_javac_as_javacompile():
                                                "guava/src/com/x/B.java")
 
 
+# ---- depSet resolution (aquery input closures) ------------------------------
+# Regression tests for the DAG walk behind TsProgram's input closure. This path
+# had NO coverage, and the original implementation was unusable on any large
+# graph: on cloudflare/workerd it was OOM-killed at 2.7GB having enumerated 349M
+# artifact IDs, because it counted PATHS through a shared DAG rather than nodes.
+
+def _depset_container(dsets):
+    return {"depSetOfFiles": [dict(d) for d in dsets]}
+
+
+def test_depsets_resolve_transitively():
+    r = extract_bazel.DepsetResolver(_depset_container([
+        {"id": 1, "directArtifactIds": [10], "transitiveDepSetIds": [2, 3]},
+        {"id": 2, "directArtifactIds": [20]},
+        {"id": 3, "directArtifactIds": [30], "transitiveDepSetIds": [4]},
+        {"id": 4, "directArtifactIds": [40]},
+    ]))
+    assert sorted(r.resolve([1])) == [10, 20, 30, 40]
+    # a leaf depSet resolves to just its own artifacts
+    assert sorted(r.resolve([3])) == [30, 40]
+    # unions of several depSets, and unknown ids, are handled
+    assert sorted(r.resolve([2, 4])) == [20, 40]
+    assert r.resolve([999]) == []
+    assert r.resolve([]) == []
+
+
+def test_depsets_dedupe_diamond():
+    """A depSet reachable by two paths must be counted ONCE.
+
+    The original implementation concatenated child LISTS, so a shared node was
+    repeated once per path through the DAG -- counting paths, not nodes.
+    """
+    r = extract_bazel.DepsetResolver(_depset_container([
+        {"id": 1, "transitiveDepSetIds": [2, 3]},
+        {"id": 2, "directArtifactIds": [99], "transitiveDepSetIds": [4]},
+        {"id": 3, "directArtifactIds": [99], "transitiveDepSetIds": [4]},
+        {"id": 4, "directArtifactIds": [99, 100]},
+    ]))
+    assert sorted(r.resolve([1])) == [99, 100]
+
+
+def test_depsets_do_not_blow_up_on_shared_dag():
+    """The workerd blocker, in miniature.
+
+    A chain where every level references the two levels below it has a number of
+    ROOT->LEAF PATHS that grows like Fibonacci, while the node count grows
+    linearly. Path-counting flattening is therefore exponential in the depth: at
+    depth 60 it would enumerate ~1e12 entries. A visited-set walk is linear, so
+    this returns immediately.
+    """
+    depth = 60
+    dsets = [{"id": 1, "directArtifactIds": [1]},
+             {"id": 2, "directArtifactIds": [2]}]
+    for i in range(3, depth + 1):
+        dsets.append({"id": i, "directArtifactIds": [i],
+                      "transitiveDepSetIds": [i - 1, i - 2]})
+    r = extract_bazel.DepsetResolver(_depset_container(dsets))
+    assert sorted(r.resolve([depth])) == list(range(1, depth + 1))
+
+
+def test_depsets_survive_a_cycle():
+    """Defensive: a self- or mutually-referencing depSet must not hang.
+
+    Real aquery output is acyclic, but the original recursion would have
+    recursed forever (RecursionError) on malformed input rather than degrading.
+    """
+    r = extract_bazel.DepsetResolver(_depset_container([
+        {"id": 1, "directArtifactIds": [10], "transitiveDepSetIds": [2]},
+        {"id": 2, "directArtifactIds": [20], "transitiveDepSetIds": [1, 2]},
+    ]))
+    assert sorted(r.resolve([1])) == [10, 20]
+
+
+class _WatchedDepset(dict):
+    """A depSet that records whether anything read its contents."""
+
+    def get(self, key, default=None):
+        if key in ("directArtifactIds", "transitiveDepSetIds"):
+            self["_read"] = True
+        return dict.get(self, key, default)
+
+
+def test_depsets_are_not_indexed_eagerly():
+    """Resolution is on demand: only the depSets actually reached are walked.
+
+    Only the TS path consumes input closures, so a build with no such action
+    (i.e. every C++ project, and workerd) must pay nothing for the rest of the
+    graph. The original implementation indexed ALL depSets up front and threw
+    the result away.
+
+    Checked behaviourally: an unreachable component must never be read. Doing
+    this with a watcher rather than by timing/memory keeps the failure a clean
+    assertion instead of an OOM.
+    """
+    reached = _WatchedDepset({"id": 1, "directArtifactIds": [10]})
+    unreached = _WatchedDepset({"id": 2, "directArtifactIds": [20],
+                                "transitiveDepSetIds": [3]})
+    r = extract_bazel.DepsetResolver({"depSetOfFiles": [reached, unreached]})
+    assert not reached.get("_read") and not unreached.get("_read"), \
+        "resolver walked the DAG at construction time"
+    assert r.resolve([1]) == [10]
+    assert reached.get("_read"), "reached depSet was not read"
+    assert not unreached.get("_read"), \
+        "resolver walked a depSet outside the requested closure"
+
+
+def test_ts_program_splits_into_per_file_tscompile_actions():
+    """TsProgram -> one TsCompile per real .ts source, via the input closure.
+
+    Also covers the filtering: .d.ts (type-only), non-src/ inputs (node_modules,
+    tsconfig) produce no TsCompile action.
+    """
+    aquery = {
+        "artifacts": [
+            {"id": 1, "pathFragmentId": 1},   # src/a.ts        -> emitted
+            {"id": 2, "pathFragmentId": 2},   # src/b.d.ts      -> type-only
+            {"id": 3, "pathFragmentId": 3},   # node_modules/x.ts -> not src/
+            {"id": 4, "pathFragmentId": 4},   # src/sub/c.ts    -> emitted
+        ],
+        "pathFragments": [
+            {"id": 10, "label": "src"},
+            {"id": 1, "label": "a.ts", "parentId": 10},
+            {"id": 2, "label": "b.d.ts", "parentId": 10},
+            {"id": 11, "label": "node_modules"},
+            {"id": 3, "label": "x.ts", "parentId": 11},
+            {"id": 12, "label": "sub", "parentId": 10},
+            {"id": 4, "label": "c.ts", "parentId": 12},
+        ],
+        "targets": [{"id": 1, "label": "//:ts"}],
+        # the sources arrive through a TRANSITIVE depSet, not a flat one
+        "depSetOfFiles": [
+            {"id": 1, "directArtifactIds": [1, 2], "transitiveDepSetIds": [2]},
+            {"id": 2, "directArtifactIds": [3, 4]},
+        ],
+        "actions": [{
+            "mnemonic": "TsProgram", "targetId": 1, "inputDepSetIds": [1],
+            "arguments": ["tsc", "--outDir",
+                          "bazel-out/k8-fastbuild/bin/out-build"],
+        }],
+    }
+    with tempfile.TemporaryDirectory() as root:
+        aq_path = os.path.join(root, "aquery.json")
+        with open(aq_path, "w") as f:
+            json.dump(aquery, f)
+        b = extract_bazel.extract(aq_path, "/repo")
+        t = b.targets["<tscompile>"]
+        assert all(a.mnemonic == "TsCompile" for a in t.actions)
+        assert sorted(a.inputs[0] for a in t.actions) == ["src/a.ts",
+                                                          "src/sub/c.ts"]
+        outs = {a.inputs[0]: a.outputs for a in t.actions}
+        assert outs["src/a.ts"] == ("out-build/a.js", "out-build/a.js.map")
+        assert outs["src/sub/c.ts"] == ("out-build/sub/c.js",
+                                        "out-build/sub/c.js.map")
+        # role is set by the extractor and must not be demoted to AGGREGATE
+        assert t.role.value == "production", t.role
+
+
 if __name__ == "__main__":
     import traceback
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]


### PR DESCRIPTION
## What

`extract_bazel._build_depset_index()` eagerly flattened **every** `depSetOfFiles` in the aquery output into a **list** of leaf artifact IDs. Both halves of that are wrong on a real graph, and pointing the engine at [cloudflare/workerd](https://github.com/cloudflare/workerd) (Bazel-native, 722 C++ actions over 2052 depSets) made it fatal — extraction was **OOM-killed**.

Two independent defects:

- **Lists, not sets.** aquery input closures are a heavily-shared DAG, so concatenating each child's result counts *paths* through the graph, not *nodes*. Measured growth on workerd: 12.9M artifact IDs at depSet 200, **349M at depSet 400 (2.7 GB RSS)**, then killed. The deduplicated closure of the entire graph is 5.6M IDs, and the largest single closure is 13k.
- **Eager, not lazy.** Only the TS path (`TsProgram`) ever consumes an input closure. On any C++ project — workerd included, which has *zero* `TsProgram` actions — 100% of that work was computed and discarded.

Replaced with a `DepsetResolver` that walks from the requested roots with a visited set: cost is linear in reachable nodes+edges, and nothing outside the requested closure is touched.

Two deliberate choices worth flagging for review:

- **It does not memoize closures.** The overlap between closures is precisely what made materializing them expensive, and `resolve()` is called once per consuming action — a handful of times per build.
- **The walk is iterative**, which also removes the recursion that would previously have blown the stack on a deep graph.

The original docstring shows how it went wrong: it generalized the DAG *shape* ("so the extractor works for any future custom rule that shares depSets via transitivity") while keeping an accumulation strategy that only works for a tree.

## Tests

This path had **no coverage whatsoever**. Added five tests, and verified each of the four bug-catchers **fails against the pre-fix implementation**:

| test | pre-fix behaviour |
|---|---|
| diamond sharing counted once | `AssertionError` |
| Fibonacci-shaped graph (path count exponential in depth) | `MemoryError` at a 2 GB cap |
| cyclic graph degrades instead of hanging | `RecursionError` |
| on-demand resolution | `AssertionError: walked the DAG at construction time` |

My first attempt at the laziness test was a structural check (`vars()` inspection) and it **passed against the buggy code**, so I replaced it with a watcher dict that records reads — an eager implementation now fails with a clean assertion instead of an OOM.

Also added the first end-to-end `TsProgram` test (the consumer of this code), covering `.d.ts`/non-`src` filtering, per-file output derivation, and that sources arriving via a *transitive* depSet are found.

## Verification

- All 7 engine suites pass.
- On workerd's real aquery output the unmodified extractor now completes at **51 MB peak RSS** (vs. OOM-killed at 2.7 GB), emitting **byte-identical actions** to a monkeypatched reference run.

## Notes for the reviewer

- This is a hard blocker for **any** large migration, not a workerd quirk: any graph with a wide shared-header DAG hits it.
- Scoped deliberately to the OOM fix alone. The workerd probe also turned up an extension-matching defect and a leaked compiler path, plus write-up and follow-ups; those are separate and not in this PR.
